### PR TITLE
Change version line to use --abrev=0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -55,7 +55,7 @@ parts:
       snap/gnome-system-monitor/current/usr: usr
     override-pull: |
       snapcraftctl pull
-      snapcraftctl set-version $(git describe --tags --abbrev=10)
+      snapcraftctl set-version $(git describe --tags --abbrev=0)
       sed -i.bak -e 's|Icon=org.gnome.SystemMonitor$|Icon=${SNAP}/meta/gui/org.gnome.SystemMonitor.svg|g' gnome-system-monitor.desktop.in.in
       sed -i.bak -E -e 's|^(NotShowIn=.*)$|# \1|g' gnome-system-monitor.desktop.in.in
     override-build: |


### PR DESCRIPTION
## Description

Change the sed line that sets the version string to use --abrev=0 instead of --abrev=10 so we no longer have the git hash in the version.

## Type of change

Please check only the options that are relevant.

- [x] General maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
